### PR TITLE
Add interactive Plotly view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Aplicación web sencilla para etiquetar series de tiempo en archivos CSV y calcu
 - Etiquetado de rangos de filas con una etiqueta personalizada.
 - Cálculo de estadísticas (media, mediana, promedio energético, percentiles 90 y 10) sobre los datos completos o filtrados por etiqueta.
 - Interfaz basada en Flask y Bootstrap.
+- Visualización interactiva con Plotly para seleccionar rangos y columna a analizar.
 - Imagen Docker para una ejecución sencilla.
 
 ## Uso
@@ -25,5 +26,6 @@ Aplicación web sencilla para etiquetar series de tiempo en archivos CSV y calcu
    ```
 
 3. Abrir el navegador en `http://localhost:8080` y seguir las instrucciones para subir el CSV.
+   Luego de cargar un archivo, se puede acceder al gráfico interactivo desde la vista de datos.
 
 El CSV debe tener la columna de tiempo en la primera posición y los datos numéricos en la segunda columna. Si no existe una columna de etiqueta, la aplicación la agregará automáticamente.

--- a/app/templates/data.html
+++ b/app/templates/data.html
@@ -18,7 +18,8 @@
     </form>
 </div>
 <div class="mb-3">
-    <a class="btn btn-primary" href="/stats/{{ filename }}">Ver estadísticas</a>
+    <a class="btn btn-primary me-2" href="/stats/{{ filename }}">Ver estadísticas</a>
+    <a class="btn btn-secondary" href="/plot/{{ filename }}">Gráfico interactivo</a>
 </div>
 <div class="table-responsive">
 {{ tables|safe }}

--- a/app/templates/plot.html
+++ b/app/templates/plot.html
@@ -1,0 +1,66 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Explorar datos: {{ filename }}</h2>
+<div class="mb-3">
+    <label for="column-select" class="form-label">Columna</label>
+    <select id="column-select" class="form-select">
+        {% for col in columns %}
+        <option value="{{ col }}">{{ col }}</option>
+        {% endfor %}
+    </select>
+</div>
+<div id="graph" style="height:400px;"></div>
+<h3 class="mt-3">Descriptores de la selección</h3>
+<table class="table" id="stats-table">
+    <tr><th>Media</th><td id="stat-media"></td></tr>
+    <tr><th>Mediana</th><td id="stat-mediana"></td></tr>
+    <tr><th>Promedio Energético Ruido</th><td id="stat-rms"></td></tr>
+    <tr><th>Percentil 90</th><td id="stat-p90"></td></tr>
+    <tr><th>Percentil 10</th><td id="stat-p10"></td></tr>
+</table>
+<a class="btn btn-secondary" href="/data/{{ filename }}">Volver</a>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script>
+function loadData(){
+    const column = document.getElementById('column-select').value;
+    fetch(`/data_json/{{ filename }}?column=${column}`)
+        .then(r=>r.json())
+        .then(data=>{
+            const trace = {x: data.x, y: data.y, mode: 'lines+markers', name: column};
+            Plotly.newPlot('graph', [trace], {dragmode:'select'}).then(gd => {
+                gd.on('plotly_selected', function(evt){
+                    if(!evt) return;
+                    const indices = evt.points.map(pt => pt.pointIndex);
+                    sendSelection(indices);
+                });
+            });
+        });
+}
+function clearStats(){
+    ['media','mediana','rms','p90','p10'].forEach(id=>{
+        document.getElementById('stat-'+id).textContent='';
+    });
+}
+document.getElementById('column-select').addEventListener('change', () => {
+    clearStats();
+    loadData();
+});
+function sendSelection(indices){
+    const column = document.getElementById('column-select').value;
+    fetch(`/compute_stats/{{ filename }}`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({column:column, indices:indices})
+    }).then(r=>r.json()).then(stats=>{
+        document.getElementById('stat-media').textContent = stats.media?.toFixed(2);
+        document.getElementById('stat-mediana').textContent = stats.mediana?.toFixed(2);
+        document.getElementById('stat-rms').textContent = stats.promedio_energetico_ruido?.toFixed(2);
+        document.getElementById('stat-p90').textContent = stats.p90?.toFixed(2);
+        document.getElementById('stat-p10').textContent = stats.p10?.toFixed(2);
+    });
+}
+document.addEventListener('DOMContentLoaded', () => {
+    loadData();
+});
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 pandas
 numpy
+plotly


### PR DESCRIPTION
## Summary
- allow interactive exploration with Plotly selecting any column
- expose endpoints `/plot/<filename>`, `/data_json/<filename>` and `/compute_stats/<filename>`
- add Plotly frontend that posts selected points to the backend
- link to the new view from the data page
- document Plotly feature and add dependency

## Testing
- `python -m py_compile app/app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_6862a4990ae48324aca19357e2c2b93d